### PR TITLE
Improve positioning of "about" section blurbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,6 @@
     </div>
 
     <div class="about" id="about">
-
       <div class="tessellactation-container">
         <canvas id="tessellactation"></canvas>
       </div>
@@ -191,31 +190,37 @@
         <!-- <h2 class="ossm">Open&nbsp;Source&nbsp;Solid&nbsp;Modeling</h2> -->
       </div>
 
-      <table class="icon-table">
-        <tr>
-          <td class="intro1">
-            <img src="img/icon-open.png" class="pad" alt="Open Source!">
-            <h2 class="intro-topic">Open Source!</h2>
-            <p class="intro-main">
-              100% FREE with people all over the world contributing their thoughts.  Escape vendor lock-in, for any purpose, forever.
-            </p>
-          </td>
-          <td class="intro1">
-            <img src="img/icon-love.png" class="pad" alt="Join Us!">
-            <h2 class="intro-topic">Join Us!</h2>
-            <p class="intro-main">
-              Help make a better CAD system, make modeling fun.  No experience necessary.  <br/><a href="https://www.flossmanuals.net/contributors-guide-to-brl-cad/" class="nots-opts1">Learn&nbsp;More</a>
-            </p>
-          </td>
-          <td class="intro1">
-            <img src="img/icon-3d.png" class="pad" alt="Solid Modeling!">
-            <h2 class="intro-topic">Solid Modeling!</h2>
-            <p class="intro-main">
-              Hybrid CSG and B-REP kernel with innovative methods for unambiguous 3D geometry.  Verification, validation, performant.
-            </p>
-          </td>
-        </tr>
-      </table>
+      <div class="icons-blurbs">
+        <div>
+          <img src="img/icon-open.png" alt="Open Source!"/>
+          <h2 class="intro-topic">Open Source!</h2>
+          <p class="intro-main">
+            100% FREE with people all over the world contributing
+            their thoughts.  Escape vendor lock-in, for any purpose,
+            forever.
+          </p>
+        </div>
+       <div>
+          <img src="img/icon-love.png" alt="Join Us!"/>
+          <h2 class="intro-topic">Join Us!</h2>
+          <p class="intro-main">
+            Help make a better CAD system, make modeling fun.  No
+            experience necessary.
+            <br/><a href="https://www.flossmanuals.net/contributors-guide-to-brl-cad/"
+            class="nots-opts1">Learn&nbsp;More</a>
+          </p>
+        </div>
+        <div>
+          <img src="img/icon-3d.png" alt="Solid Modeling!"/>
+          <h2 class="intro-topic">Solid Modeling!</h2>
+          <p class="intro-main">
+            Hybrid CSG and B-REP kernel with innovative methods for
+            unambiguous 3D geometry.  Verification, validation,
+            performant.
+          </p>
+        </div>
+      </div>
+      <div id="icons-blurbs-background"></div>
     </div>
     <div class="what-r">
       <h2 class="intro-topic">What is BRL&#8209;CAD?</h2>

--- a/js/tessellactation.js
+++ b/js/tessellactation.js
@@ -1,6 +1,6 @@
 (function() {
 
-  var top, width, height, largeHeader, canvas, ctx, points, mouse = true;
+  var top, width, height, canvas, ctx, points, mouse = true;
   var animateHeader = true;
 
   // Main
@@ -9,10 +9,16 @@
   addListeners();
 
   function initHeader() {
-    largeHeader = document.getElementById('about');
     canvas = document.getElementById('tessellactation');
 
-    height = largeHeader.clientHeight;
+    /* The portion of about in which this should run is always going
+     * to be 350px tall.  Setting this statically to 350px is in this
+     * case better than calculating it from another element, since the
+     * only relevant property is the (position: absolute) y-coordinate
+     * of the background ::after div.  In the long run, it may be a
+     * good idea to modify the site to have a better-sized container
+     * for this, and to build all sizes dynamically and scalably. */
+    height = 350;
     width = window.innerWidth;
 
     mouse = {x: 48 + canvas.offsetLeft, y: 48 + canvas.offsetTop};
@@ -103,7 +109,6 @@
   }
 
   function resize() {
-    height = largeHeader.clientHeight;
     width = window.innerWidth;
 
     canvas.height = height;

--- a/style.css
+++ b/style.css
@@ -77,6 +77,7 @@ a:hover{
     border-radius: 50%;
     background: #000;
     z-index: 2;
+    position: relative;
 }
 .logomenu{
     text-align: center;
@@ -113,23 +114,74 @@ a.menu{
 
 /**First**/
 .about{
-    left: 64px;
-    padding: 25px;
+    padding-top: 25px;
     font-size: 23px;
     background: #2d2d2d;
     text-align: center;
-    height: 300px;
+    position: relative;
+    overflow: hidden;
 }
+.icons-blurbs img {
+    height: 180px;
+    width: 180px;
+}
+.icons-blurbs {
+    position: relative;
+    width: calc(90% - 0.9 * 50px - 10px);
+    padding: 0 calc(5% + 0.9 * 25px + 5px);
+    overflow: hidden;
+}
+.icons-blurbs div {
+    position: relative;
+    width: calc(100% / 3 - 30px / 3);
+    float: left;
+    padding-top: 20px;
+    padding-left: 5px;
+    padding-right: 5px;
+    text-align: center;
+    vertical-align: top;
+    z-index: 2;
+}
+.icons-blurbs::after {
+    visibility:hidden;
+    display: block;
+    font-size: 0;
+    content: " ";
+    clear: both;
+    height: 0;
+}
+#icons-blurbs-background::before {
+    background-color: #000000;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    z-index: 1;
+    left: 0px;
+    top: 350px;
+    content: "";
+}
+#icons-blurbs-background::after {
+    background-color: #ffffff;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    z-index: 1;
+    left: 0px;
+    top: 361px;
+    content: "";
+}
+
 .tessellactation-container{
     /* FIXME: figure out how to position the canvas beneath the intro1 and header/menu elements */
 }
 #tessellactation{
     position: absolute;
-    top: 50pt;
+    top: 0px;
     left: 0px;
     width: 100%;
     height: 350px;
 }
+
 .main-h1{
     font-family: Intro, Segoe UI, Open Sans, Arial, sans-serif;
     font-size: 100px;
@@ -177,6 +229,7 @@ a.menu{
     -1px 1px 0 #111,
     1px 1px 0 #111;
 }
+
 .byline{
     position: relative;
     font-family: Intro, Segoe UI, Open Sans, Arial, sans-serif;
@@ -190,50 +243,21 @@ a.menu{
     -1px 1px 0 #111,
     1px 1px 0 #111;
 }
-.pad{
-    padding-top: 20px;
-    height: 180px;
-    width: 180px;
-    color:#999;       
-    transition: padding 0.2s linear; /* vendorless fallback */
-    -o-transition: color 0.5s linear; /* opera */
-    -ms-transition: color 0.5s linear; /* IE 10 */
-    -moz-transition: color 0.5s linear; /* Firefox */
-    -webkit-transition: padding 0.2s linear; /*safari and chrome */
-}
-.pad:hover{
-    padding-top: 10px;
-}
+
 .main-intro{
     font-family: Segoe UI, Open Sans, Arial, sans-serif;
     font-size: 30px;
 }
+
 .wrapper-main{
     width: 60%;
     margin: 0px auto;
     padding-top: 40px;
+    padding-bottom: 40px;
+    position: relative;
+    z-index: 3;
 }
-.icon-table{
-    width: 90%;
-    margin: 10px auto;
-    margin-top: 40px;
-    border-spacing: 10px 0px;
-}
-.intro1{
-    text-align: center;
-    vertical-align: top;
-    width: 33%;
-}
-.intro2{
-    text-align: center;
-    vertical-align: top;
-    width: 33%;
-}
-.intro3{
-    text-align: center;
-    vertical-align: top;
-    width: 33%;
-}
+
 .intro-topic{
     font-family: Intro, Segoe UI, Open Sans, Arial, sans-serif;
     font-size: 32px;
@@ -243,11 +267,10 @@ a.menu{
     font-weight: lighter;
     margin: 5px;
 }
+
 .what-r{
     margin: 10px auto;
-    margin-top: 380px;
     background: #000;
-/*     background: #f64747; */
     color: #fff;
     padding: 40px 90px 40px 90px;
     text-align: center;
@@ -771,11 +794,9 @@ a.menu{
                     display: none;
                 }
                 .about{
-                    padding: 10px;
+                    padding-top: 10px;
                     background: #2d2d2d;
-/*                    background: url("img/intro-background.gif"); */
                     text-align: center;
-                    height: 200px;
                 }
                 .tessellactation-container{
                     display: none;
@@ -819,10 +840,17 @@ a.menu{
                 .main-intro{
                     font-size: 17px;
                 }
-                .pad{
+                .icons-blurbs img{
                     width: 100px;
                     height: 100px;
                     margin-top: 0px;
+                }
+                .icons-blurbs {
+                    width: calc(90% - 0.9 * 20px - 10px);
+                    padding: 0 calc(5% + 0.9 * 10px + 5px);
+                }
+                #icons-blurbs-background::after {
+                    top: 220px;
                 }
                 .intro-topic{
                     font-size: 17px;


### PR DESCRIPTION
Previously, the about section element had a static fixed height,
excluding the height of the three icons and blurbs at the bottom, and
space was reserved for those through the use of a large static fixed top
margin on the following element.  This caused significant problems in
cases where the height of the reflowed blurb text exceeded the expected
height, and can also look bad when the text is shorter than expected,
resulting in a large expanse of white appearing beneath the blurbs.
This commit modifies the markup to make those blurb heights be
considered part of the about section, while maintaining the exact
positioning of most elements and backgrounds.  Several pixel constants
are still used in order to keep the site looking precisely as it did
before; in the future, it may be a good idea to make the sizing of
various other elements more dynamic as well.  The positioning of the
icons, blurbs, BRL-CAD logo, and white background behind the blurbs is,
to the pixel, the same as it was before, although the lower bound of the
white background behind the blurbs now resizes based on the calculated
height of the blurb, providing the desired functionality.  There is a
single deviation in appearance from the previous version: the thin black
bar between the aforementioned white background and the background of
the BRL-CAD logo is now a fixed height.  This compromise was accepted
due to the impossibility of reproducing the previous arrangement without
accepting influences on the section from markup in other regions:
previously, the bar was generated by the lower padding of the items in
the menu, and as such depended on the font size, baseline alignment,
etc. of those menu items.